### PR TITLE
Crashes with Sheetmetal [BUG]

### DIFF
--- a/PartColorizer.vb
+++ b/PartColorizer.vb
@@ -86,7 +86,7 @@ Public Class Form_PartColorizer
 
         End Select
 
-        Dim objPart As SolidEdgePart.PartDocument = objApp.ActiveDocument
+        Dim objPart As Object = objApp.ActiveDocument
         Dim tmpName As String = objPart.FullName
 
 


### PR DESCRIPTION
Crashes with sheet metal. Fix reflects how Form_PartColorizer_Load deals with both object types by using generic object class.